### PR TITLE
Add version cvar

### DIFF
--- a/The Last Stand/l4d_sweep_fist_patch/l4d_sweep_fist_patch.sp
+++ b/The Last Stand/l4d_sweep_fist_patch/l4d_sweep_fist_patch.sp
@@ -95,6 +95,7 @@ public void OnPluginStart()
 	
 	delete hGameData;
 	
+	CreateConVar("l4d_sweep_fist_patch_version", PLUGIN_VERSION, "Sweep Fist Patch Version", FCVAR_DONTRECORD|FCVAR_NOTIFY|FCVAR_REPLICATED|FCVAR_SPONLY);
 	FindConVar("mp_gamemode").AddChangeHook(OnGameModeChanged);
 }
 


### PR DESCRIPTION
Hello, please add version cvar for tracking. I use these same patches in Mutant Tanks and I have it set to disable certain patches if a specific cvar is found. It would help end-users from getting errors/conflicts if they use this plugin while Mutant Tanks is running. Thanks!