### PR TITLE
l4d_transition_entity: Attempt to fix omitted transitioned entities

### DIFF
--- a/The Last Stand/l4d_transition_entity/gamedata/l4d_transition_entity.txt
+++ b/The Last Stand/l4d_transition_entity/gamedata/l4d_transition_entity.txt
@@ -146,37 +146,20 @@
 								// 53 56 8B 74 24 0C 8B 06 8B 90 84 00 00 00
 			}
 
-			/**
-			 * KeyValues::GetString(char const*, char const*)
-			 *
-			 * How to find on Windows:
-			 * 1. Search for the "%3.2f: Director: Finale state = FINALE_HORDE_ATTACK_1\n" string.
-			 * 2. Both functions that reference the string call this function.
-			 * 3. The second function call below the string should be this function.
-			 **/
-			"KeyValues::GetString"
+			"KeyValues::GetInt"
 			{
-				"library"	"server"
-				"linux"		"@_ZN9KeyValues9GetStringEPKcS1_"
-				"mac"		"@_ZN9KeyValues9GetStringEPKcS1_"
-				"windows"	"\x2A\x2A\x2A\x2A\x2A\x2A\x53\x8B\x9C\x2A\x2A\x2A\x2A\x2A\x56\x57\x6A\x2A\x53\x8B\x2A\xE8\x2A\x2A\x2A\x2A\x8B\x2A\x85\x2A\x0F\x84\x2A\x2A\x2A\x2A\x0F\x2A\x2A\x2A\x83\x2A\x2A\x83\x2A\x2A\x0F"
-						/* ? ? ? ? ? ? 53 8B 9C ? ? ? ? ? 56 57 6A ? 53 8B ? E8 ? ? ? ? 8B ? 85 ? 0F 84 ? ? ? ? 0F ? ? ? 83 ? ? 83 ? ? 0F */
+				"library"		"server"
+				"linux"			"@_ZN9KeyValues6GetIntEPKci"
+				"windows"		"\x8B\x44\x24\x04\x6A\x00\x50\xE8\x2A\x2A\x2A\x2A\x85\xC0\x74\x2A\x0F\xBE\x48\x10"
+								// 8B 44 24 04 6A 00 50 E8 ? ? ? ? 85 C0 74 ? 0F BE 48 10
 			}
 
-			/**
-			 * KeyValues::SetString(char const*, char const*)
-			 *
-			 * How to find on Windows:
-			 * 1. Locate the "KeyValues::GetString" function.
-			 * 2. This function should be the last function call in that function.
-			 **/
-			"KeyValues::SetString"
+			"KeyValues::SetInt"
 			{
-				"library"	"server"
-				"linux"		"@_ZN9KeyValues9SetStringEPKcS1_"
-				"mac"		"@_ZN9KeyValues9SetStringEPKcS1_"
-				"windows"	"\x2A\x2A\x2A\x2A\x2A\x2A\x2A\x50\xE8\x2A\x2A\x2A\x2A\x8B\x2A\x85\x2A\x74\x2A\x8B\x2A\x2A\x53"
-						/* ? ? ? ? ? ? ? 50 E8 ? ? ? ? 8B ? 85 ? 74 ? 8B ? ? 53 */
+				"library"		"server"
+				"linux"			"@_ZN9KeyValues6SetIntEPKci"
+				"windows"		"\x8B\x44\x24\x04\x6A\x01\x50\xE8\x2A\x2A\x2A\x2A\x85\xC0\x74\x2A\x8B\x4C\x24\x08\x89\x48\x0C\xC6\x40\x10\x02"
+								// 8B 44 24 04 6A 01 50 E8 ? ? ? ? 85 C0 74 ? 8B 4C 24 08 89 48 0C C6 40 10 02
 			}
 		}
 	}
@@ -239,36 +222,20 @@
 								// 55 8B EC 53 56 8B 75 08 8B 06 8B 90 ? ? ? ? 8B CE FF D2 8B
 			}
 
-			/**
-			 * KeyValues::GetString(char const*, char const*)
-			 *
-			 * How to find on Windows:
-			 * 1. Search for the "L4D2C" string.
-			 * 2. Both functions that reference the string call this function.
-			 **/
-			"KeyValues::GetString"
+			"KeyValues::GetInt"
 			{
-				"library"	"server"
-				"linux"		"@_ZN9KeyValues9GetStringEPKcS1_"
-				"mac"		"@_ZN9KeyValues9GetStringEPKcS1_"
-				"windows"	"\x2A\x2A\x2A\x2A\x2A\x2A\x2A\x2A\x2A\xA1\x2A\x2A\x2A\x2A\x33\x2A\x89\x2A\x2A\x53\x8B\x2A\x2A\x56\x57\x6A\x2A\x53\x8B\x2A\xE8\x2A\x2A\x2A\x2A\x8B\x2A\x85\x2A\x0F\x84\x2A\x2A\x2A\x2A\x0F\x2A\x2A\x2A\x48\x83\x2A\x2A\x0F\x87\x2A\x2A\x2A\x2A\xFF\x24\x2A\x2A\x2A\x2A\x2A\xD9\x2A\x2A\x83\x2A\x2A\xDD\x2A\x2A\x68"
-						/* ? ? ? ? ? ? ? ? ? A1 ? ? ? ? 33 ? 89 ? ? 53 8B ? ? 56 57 6A ? 53 8B ? E8 ? ? ? ? 8B ? 85 ? 0F 84 ? ? ? ? 0F ? ? ? 48 83 ? ? 0F 87 ? ? ? ? FF 24 ? ? ? ? ? D9 ? ? 83 ? ? DD ? ? 68 */
+				"library"		"server"
+				"linux"			"@_ZN9KeyValues6GetIntEPKci"
+				"windows"		"\x55\x8B\xEC\x8B\x45\x08\x6A\x00\x50\xE8\x2A\x2A\x2A\x2A\x85\xC0\x74\x2A\x0F\xBE\x48\x10"
+								// 55 8B EC 8B 45 08 6A 00 50 E8 ? ? ? ? 85 C0 74 ? 0F BE 48 10
 			}
 
-			/**
-			 * KeyValues::SetString(char const*, char const*)
-			 *
-			 * How to find on Windows:
-			 * 1. Locate the "KeyValues::GetString" function.
-			 * 2. This function should be the last function call in that function.
-			 **/
-			"KeyValues::SetString"
+			"KeyValues::SetInt"
 			{
-				"library"	"server"
-				"linux"		"@_ZN9KeyValues9SetStringEPKcS1_"
-				"mac"		"@_ZN9KeyValues9SetStringEPKcS1_"
-				"windows"	"\x2A\x2A\x2A\x2A\x2A\x2A\x56\x6A\x2A\x50\xE8\x2A\x2A\x2A\x2A\x8B\x2A\x85\x2A\x74\x2A\x8B\x2A\x2A\x53\x57\x51\xE8\x2A\x2A\x2A\x2A\x8B\x2A\x2A\x52\xE8\x2A\x2A\x2A\x2A\x8B\x2A\x2A\x83\x2A\x2A\xC7\x46\x2A\x2A\x2A\x2A\x2A\x85\x2A\x75\x2A\xBB\x2A\x2A\x2A\x2A\x53"
-						/* ? ? ? ? ? ? 56 6A ? 50 E8 ? ? ? ? 8B ? 85 ? 74 ? 8B ? ? 53 57 51 E8 ? ? ? ? 8B ? ? 52 E8 ? ? ? ? 8B ? ? 83 ? ? C7 46 ? ? ? ? ? 85 ? 75 ? BB ? ? ? ? 53 */
+				"library"		"server"
+				"linux"			"@_ZN9KeyValues6SetIntEPKci"
+				"windows"		"\x55\x8B\xEC\x8B\x45\x08\x6A\x01\x50\xE8\x2A\x2A\x2A\x2A\x85\xC0\x74\x2A\x8B\x4D\x0C\x89\x48\x0C\xC6\x40\x10\x02"
+								// 55 8B EC 8B 45 08 6A 01 50 E8 ? ? ? ? 85 C0 74 ? 8B 4D 0C 89 48 0C C6 40 10 02
 			}
 		}
 	}


### PR DESCRIPTION
Thanks to @fbef0102 for testing and reporting.

Fix:
- Fixed an issue where `SavedEntity` isn't hooked sucessfully due to an existing hook manager on the same address.

Change:
- Replaced KeyValues string accessors with integer ones.