### PR TITLE
workflow: Release regardless of all SM builds successfully completed

### DIFF
--- a/.github/workflows/compile_release.yml
+++ b/.github/workflows/compile_release.yml
@@ -52,7 +52,6 @@ jobs:
 
       - name: Compile plugins
         working-directory: ${{ env.SCRIPTS_PATH }}/
-        id: compile_step
         run: |
           error_files=()
           for dir in */


### PR DESCRIPTION
Allow compilation of plugins to continue on error.